### PR TITLE
Add support for Avalonia 12/future with multi-version builds

### DIFF
--- a/Avalonia.SpellChecker.Demo/Avalonia.SpellChecker.Demo.csproj
+++ b/Avalonia.SpellChecker.Demo/Avalonia.SpellChecker.Demo.csproj
@@ -1,20 +1,40 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+    <!-- Default to latest version -->
+    <AvaloniaVersion Condition="'$(AvaloniaVersion)' == ''">12</AvaloniaVersion>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.1.3" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.1.3" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.3" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.1.3" />
+  <PropertyGroup Condition="'$(AvaloniaVersion)' == '11'">
+    <TargetFramework>net8.0</TargetFramework>
+    <DefineConstants>AVALONIA_11</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(AvaloniaVersion)' == '12'">
+    <TargetFramework>net10.0</TargetFramework>
+    <DefineConstants>AVALONIA_12</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(AvaloniaVersion)' == '11'">
+    <PackageReference Include="Avalonia" Version="11.*" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.*" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.*" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.*" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.3" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.*" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(AvaloniaVersion)' == '12'">
+    <PackageReference Include="Avalonia" Version="12.*" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.*" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.*" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.*" />
+    <!--Condition below is needed to remove Avalonia.DiagnosticsSupport package from build output in Release configuration.-->
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="AvaloniaUI.DiagnosticsSupport" Version="2.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Avalonia.SpellChecker/Avalonia.SpellChecker.csproj
+++ b/Avalonia.SpellChecker/Avalonia.SpellChecker.csproj
@@ -72,8 +72,12 @@
 	  </None>
 	</ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="WeCantSpell.Hunspell" Version="5.0.0" />
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<PackageReference Include="WeCantSpell.Hunspell" Version="6.*" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net10.0'">
+		<PackageReference Include="WeCantSpell.Hunspell" Version="7.*" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(AvaloniaVersion)' == '11'">

--- a/Avalonia.SpellChecker/Avalonia.SpellChecker.csproj
+++ b/Avalonia.SpellChecker/Avalonia.SpellChecker.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -16,6 +15,20 @@
 		<Copyright>© 2024 Gustavo Augusto Hennig</Copyright>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<!-- Default to latest version -->
+		<AvaloniaVersion Condition="'$(AvaloniaVersion)' == ''">12</AvaloniaVersion>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(AvaloniaVersion)' == '11'">
+		<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+		<DefineConstants>AVALONIA_11</DefineConstants>
+		<PackageVersion>$(Version)-avalonia11</PackageVersion>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(AvaloniaVersion)' == '12'">
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+		<DefineConstants>AVALONIA_12</DefineConstants>
+		<PackageVersion>$(Version)-avalonia12</PackageVersion>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -61,6 +74,13 @@
 
 	<ItemGroup>
 		<PackageReference Include="WeCantSpell.Hunspell" Version="5.0.0" />
-		<PackageReference Include="Avalonia" Version="11.1.3" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(AvaloniaVersion)' == '11'">
+		<PackageReference Include="Avalonia" Version="11.*" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(AvaloniaVersion)' == '12'">
+		<PackageReference Include="Avalonia" Version="12.*" />
 	</ItemGroup>
 </Project>

--- a/Avalonia.SpellChecker/SpellCheckerTextPresenter.cs
+++ b/Avalonia.SpellChecker/SpellCheckerTextPresenter.cs
@@ -61,8 +61,8 @@ public class SpellCheckerTextPresenter : TextPresenter
         // Create default TextRunProperties without any text decorations
         var defaultTextRunProperties = new GenericTextRunProperties(
             typeface,
-            FontFeatures,
-            FontSize,
+            fontFeatures: FontFeatures,
+            fontRenderingEmSize: FontSize,
             textDecorations: null, // No decorations by default
             foregroundBrush: foreground);
 
@@ -71,7 +71,9 @@ public class SpellCheckerTextPresenter : TextPresenter
         if (!string.IsNullOrEmpty(preeditText))
         {
             var preeditHighlight = new ValueSpan<TextRunProperties>(caretIndex, preeditText.Length,
-                    new GenericTextRunProperties(typeface, FontFeatures, FontSize,
+                    new GenericTextRunProperties(typeface,
+                    fontFeatures: FontFeatures,
+                    fontRenderingEmSize: FontSize,
                     foregroundBrush: foreground,
                     textDecorations: TextDecorations.Underline));
 
@@ -90,7 +92,9 @@ public class SpellCheckerTextPresenter : TextPresenter
                             start,
                             length,
                             new GenericTextRunProperties(
-                                typeface, FontFeatures, FontSize,
+                                typeface,
+                                fontFeatures: FontFeatures,
+                                fontRenderingEmSize: FontSize,
                                 foregroundBrush: SelectionForegroundBrush))
                 };
             }
@@ -114,8 +118,8 @@ public class SpellCheckerTextPresenter : TextPresenter
 
                 var underlineProp = new GenericTextRunProperties(
                                         typeface,
-                                        FontFeatures,
-                                        FontSize,
+                                        fontFeatures: FontFeatures,
+                                        fontRenderingEmSize: FontSize,
                                         textDecorations: misspellesWordTextDecorations,
                                         foregroundBrush: foreground);
 
@@ -246,8 +250,8 @@ public class SpellCheckerTextPresenter : TextPresenter
         var maxWidth = MathUtilities.IsZero(constraint.Width) ? double.PositiveInfinity : constraint.Width;
         var maxHeight = MathUtilities.IsZero(constraint.Height) ? double.PositiveInfinity : constraint.Height;
 
-        var textLayout = new TextLayout(text, typeface, FontFeatures, FontSize, foreground, TextAlignment,
-            TextWrapping, maxWidth: maxWidth, maxHeight: maxHeight, textStyleOverrides: textStyleOverrides,
+        var textLayout = new TextLayout(text, typeface, fontFeatures: FontFeatures, fontSize: FontSize, foreground: foreground, textAlignment: TextAlignment,
+            textWrapping: TextWrapping, maxWidth: maxWidth, maxHeight: maxHeight, textStyleOverrides: textStyleOverrides,
             flowDirection: FlowDirection, lineHeight: LineHeight, letterSpacing: LetterSpacing);
 
         return textLayout;

--- a/Avalonia.SpellChecker/SpellCheckerTextPresenter.cs
+++ b/Avalonia.SpellChecker/SpellCheckerTextPresenter.cs
@@ -247,8 +247,8 @@ public class SpellCheckerTextPresenter : TextPresenter
         IReadOnlyList<ValueSpan<TextRunProperties>>? textStyleOverrides)
     {
         var foreground = Foreground;
-        var maxWidth = MathUtilities.IsZero(constraint.Width) ? double.PositiveInfinity : constraint.Width;
-        var maxHeight = MathUtilities.IsZero(constraint.Height) ? double.PositiveInfinity : constraint.Height;
+        var maxWidth = (constraint.Width == 0) ? double.PositiveInfinity : constraint.Width;
+        var maxHeight = (constraint.Height == 0) ? double.PositiveInfinity : constraint.Height;
 
         var textLayout = new TextLayout(text, typeface, fontFeatures: FontFeatures, fontSize: FontSize, foreground: foreground, textAlignment: TextAlignment,
             textWrapping: TextWrapping, maxWidth: maxWidth, maxHeight: maxHeight, textStyleOverrides: textStyleOverrides,

--- a/Avalonia.SpellChecker/TextBoxSpellChecker.cs
+++ b/Avalonia.SpellChecker/TextBoxSpellChecker.cs
@@ -8,6 +8,12 @@ using Avalonia.VisualTree;
 using System.ComponentModel.Design;
 using System.Windows.Input;
 
+#if AVALONIA_11
+    using ContextRequestedEventArgs = Avalonia.Controls.ContextRequestedEventArgs;
+#elif AVALONIA_12
+    using ContextRequestedEventArgs = Avalonia.Input.ContextRequestedEventArgs;
+#endif
+
 namespace Avalonia.SpellChecker
 {
     /// <summary>


### PR DESCRIPTION
Add multi-version support for Avalonia using a build parameter to specify version, e.g.

```
$ dotnet build -p:AvaloniaVersion=11
$ dotnet build -p:AvaloniaVersion=12
```

Support for multiple target frameworks has also been added, matching the specified Avalonia version.

Hunspell version is now determined by target framework, e.g. 6.x for .NET 6 and 7.x for .NET 10.

Produced NuGet packages now have variant added to version, e.g. x.x.x-avalonia12