### PR TITLE
Fix getting start directory on Linux.

### DIFF
--- a/Avalonia.SpellChecker/SpellCheckerConfig.cs
+++ b/Avalonia.SpellChecker/SpellCheckerConfig.cs
@@ -1,6 +1,4 @@
-﻿using System.Reflection;
-
-namespace Avalonia.SpellChecker
+﻿namespace Avalonia.SpellChecker
 {
     /// <summary>
     /// SpellChecker settings
@@ -16,7 +14,7 @@ namespace Avalonia.SpellChecker
         {
             var config = new SpellCheckerConfig
             {
-                DictionariesFolder = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Dictionaries")
+                DictionariesFolder = Path.Combine(AppContext.BaseDirectory, "Dictionaries")
             };
 
             config.EnabledLanguages.AddRange(languages);


### PR DESCRIPTION
Getting start directory currently does not work on Linux (specifically Fedora 43 using Gnome).

Switching to using AppContext.BaseDirectory fixes this and everything else seems to work fine.